### PR TITLE
fix: whisper.cpp allows for language detection

### DIFF
--- a/whisper.el
+++ b/whisper.el
@@ -212,7 +212,8 @@ When non-English, use generic model (without .en suffix)"
              (string-suffix-p ".en" whisper-model))
     (error "Use generic model (non .en version) for non-English languages"))
 
-  (when (and (not (= 2 (length whisper-language))))
+  (unless (and (not (= 2 (length whisper-language)))
+               (string-equal "auto" whisper-language))
     (error (concat "Unknown language shortcode. For the list, see: "
                    "https://github.com/ggerganov/whisper.cpp/blob/master/whisper.cpp")))
 


### PR DESCRIPTION
Here's the upstream PR: https://github.com/ggerganov/whisper.cpp/pull/286

I've tested this successfully in my Emacs installation - primarily with German and English.

Thank you for providing whisper.el, it's very fun to use :pray:  