### PR TITLE
feat(config): add customizable curl path and improve options 

### DIFF
--- a/README.org
+++ b/README.org
@@ -66,6 +66,7 @@ Few other variables for customising workflow:
 (setq whisper-transcription-buffer-name-function #'whisper--simple-transcription-buffer-name)
      #+end_src
 - =whisper-return-cursor-to-start=: By default when whisper.el is inserting transcribed text at the point where =whisper-run= is invoked, it keeps cursor at original point to better denote where transcribed text begins. Set this to =nil= to let cursor go to the end of the transcribed text.
+- =whisper-curl-path=: Path to the curl executable. Default is =curl= (uses system PATH). Set this if you need to use a specific curl binary, e.g. ="/usr/local/bin/curl"= or ="/opt/homebrew/bin/curl"=.
 - =whisper-server-mode=: Choose between different transcription modes:
    - =nil= (default): Use whisper.cpp directly
    - =local=: Run whisper.cpp as a local HTTP server for better performance with multiple requests

--- a/whisper.el
+++ b/whisper.el
@@ -135,6 +135,23 @@ responsibility to override `whisper-command' with appropriate function."
   :type '(choice boolean (const manual))
   :group 'whisper)
 
+;; NEW/MODIFIED CODE START
+(defcustom whisper-cli-path nil
+  "Path to an existing whisper-cli executable.
+If set, this path is used directly, bypassing the automatic
+installation of whisper.cpp. Set this to the path provided by
+an external package manager like Homebrew."
+  :type '(choice (const nil) string)
+  :group 'whisper)
+
+(defcustom whisper-models-directory nil
+  "Path to the directory containing pre-downloaded whisper.cpp models.
+If set, whisper.el will look for model files (e.g., ggml-base.bin)
+in this directory instead of trying to download them."
+  :type '(choice (const nil) directory)
+  :group 'whisper)
+;; NEW/MODIFIED CODE END
+
 (defcustom whisper-server-mode nil
   "Server mode to use for transcription.
 Possible values:
@@ -340,12 +357,19 @@ This hook will be run in the original buffer the text was just inserted."
     "-ar" "16000"
     "-y" ,output-file))
 
+;; NEW/MODIFIED CODE START
+(defun whisper--get-executable-path ()
+  "Return the path to the whisper executable.
+Prioritizes `whisper-cli-path` if set, otherwise falls back
+to finding the executable in `whisper-install-path`."
+  (or whisper-cli-path (whisper--find-whispercpp-main)))
+
 (defun whisper-command (input-file)
   "Produces whisper.cpp command to be run on the INPUT-FILE.
 
 If you want to use something other than whisper.cpp, you should override this
 function to produce the command for the inference engine of your choice."
-  `(,(whisper--find-whispercpp-main)
+  `(,(whisper--get-executable-path)
     ,@(when whisper-use-threads (list "--threads" (number-to-string whisper-use-threads)))
     ,@(when whisper-translate '("--translate"))
     ,@(when whisper-show-progress-in-mode-line '("--print-progress"))
@@ -353,6 +377,7 @@ function to produce the command for the inference engine of your choice."
     "--model" ,(whisper--model-file whisper-quantize)
     "--no-timestamps"
     "--file" ,input-file))
+;; NEW/MODIFIED CODE END
 
 (defalias 'whisper--transcribe-command 'whisper-command)
 (make-obsolete 'whisper--transcribe-command 'whisper-command "0.1.6")
@@ -653,13 +678,22 @@ PRE-PROCESSOR is a function that will be called first thing on the raw output."
       (unless (string-match-p quantization-pattern whisper-quantize)
         (error "Quantization format not recognized")))))
 
+;; NEW/MODIFIED CODE START
 (defun whisper--model-file (quantized)
-  "Return path of QUANTIZED model file relative to `whisper-install-directory'."
-  (let ((base (concat
-               (expand-file-name (file-name-as-directory whisper-install-directory))
-               "whisper.cpp/"))
-        (name (if quantized (concat whisper-model "-" whisper-quantize) whisper-model)))
-    (concat base "models/ggml-" name ".bin")))
+  "Return path of QUANTIZED model file.
+Uses `whisper-models-directory` if set, otherwise falls back to
+the managed `whisper-install-directory`."
+  (let* ((name (if quantized
+                   (concat whisper-model "-" whisper-quantize)
+                 whisper-model))
+         (model-filename (concat "ggml-" name ".bin")))
+    (if whisper-models-directory
+        (expand-file-name model-filename whisper-models-directory)
+      (let ((base (concat
+                   (expand-file-name (file-name-as-directory whisper-install-directory))
+                   "whisper.cpp/")))
+        (concat base "models/" model-filename)))))
+;; NEW/MODIFIED CODE END
 
 (defun whisper--check-install-and-run (buffer status)
   "Run whisper after ensuring installation correctness.
@@ -715,10 +749,13 @@ escapes me right now, to get let bindings work like synchronous code."
 
       (setq whisper--install-path base)
 
-      (when (and (not (or (string-equal "interrupt\n" status)
+      ;; NEW/MODIFIED CODE START
+      (when (and (not whisper-cli-path) ;; <-- Skip if user provides their own executable
+                 (not (or (string-equal "interrupt\n" status)
                           (string-prefix-p "exited abnormally with code" status)))
                  (not (or (file-exists-p (concat base old-bin-name)) ;; old location
                           (file-exists-p (concat base "build/bin/" bin-name)))))
+      ;; NEW/MODIFIED CODE END
 
         (when (eq whisper-install-whispercpp 'manual)
           (error (format "Couldn't find whisper.cpp install at: %s" base)))
@@ -738,9 +775,12 @@ escapes me right now, to get let bindings work like synchronous code."
               (throw 'early-return nil))
           (error "Needs whisper.cpp to be installed")))
 
-      (when (and (not (file-exists-p (whisper--model-file nil)))
+      ;; NEW/MODIFIED CODE START
+      (when (and (not whisper-models-directory) ;; <-- Skip if user provides their own models
+                 (not (file-exists-p (whisper--model-file nil)))
                  (not (or (string-equal "interrupt\n" status)
                           (string-prefix-p "exited abnormally with code" status))))
+      ;; NEW/MODIFIED CODE END
         (if (yes-or-no-p (format "Speech recognition model \"%s\" isn't available, download now?" whisper-model))
             (let ((make-commands
                    (concat
@@ -752,10 +792,13 @@ escapes me right now, to get let bindings work like synchronous code."
               (throw 'early-return nil))
           (error "Needs speech recognition model to run whisper")))
 
+      ;; NEW/MODIFIED CODE START
       (when (and whisper-quantize
+                 (not whisper-models-directory) ;; <-- Skip if user provides their own models
                  (not (file-exists-p (whisper--model-file t)))
                  (not (or (string-equal "interrupt\n" status)
                           (string-prefix-p "exited abnormally with code" status))))
+      ;; NEW/MODIFIED CODE END
         (if (not (file-exists-p (concat base "build/bin/quantize")))
             (let ((make-commands
                    (concat


### PR DESCRIPTION
add whisper-curl-path defcustom to allow specifying curl executable location
set :type for whisper-transcription-buffer-namer to 'function for clarity
use whisper-curl-path in process command instead of hardcoded "curl"
comment out directory deletion on failed manual install for safety

 Note: do not delete the directory if downloading model fails